### PR TITLE
Added sudo to rm command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/aica-technology/ros-ws:noetic
 
-RUN sudo apt-get update && sudo apt-get install -y ros-noetic-turtlesim && rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && sudo apt-get install -y ros-noetic-turtlesim && sudo rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/${USER}/ros_ws
 COPY --chown=${USER} ./turtle_example ./src/turtle_example


### PR DESCRIPTION
Docker build failed with 'Permission denied' error when trying to remove /var/lib/apt/lists/*